### PR TITLE
fix(command-capital): Remove cap letter from generator command option

### DIFF
--- a/blueprints/ember-cordova/index.js
+++ b/blueprints/ember-cordova/index.js
@@ -11,7 +11,7 @@ module.exports = {
       name: 'name',
       type: String
     }, {
-      name: 'cordovaId',
+      name: 'cordovaid',
       type: String
     }
   ],
@@ -27,7 +27,7 @@ module.exports = {
     var projectName = this.project.name();
 
     var create = new CreateTask({
-      id: options.cordovaId || camelize(projectName),
+      id: options.cordovaid || camelize(projectName),
       name: options.name || camelize(projectName),
       project: this.project,
       ui: this.ui


### PR DESCRIPTION
Ember-cli appears to [prohibit command options with capital letters]
(https://github.com/ember-cli/ember-cli/blob/87154e7975c6be13375bb7fed977a9f63ddccb19/lib/models/command.js#L254-L257)

![screen shot 2016-04-07 at 9 59 32 pm](https://cloud.githubusercontent.com/assets/558005/14365064/08c21390-fd0c-11e5-949b-1cafcf3bce03.png)

