### PR TITLE
Use resolveRegistration rather than container.lookupFactory to get env

### DIFF
--- a/app/instance-initializers/in-app-livereload.js
+++ b/app/instance-initializers/in-app-livereload.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const { run } = Ember;
 
 export function initialize(app) {
-  let config = app.container.lookupFactory('config:environment');
+  let config = app.resolveRegistration('config:environment');
   let env = config.environment;
 
   if (config.cordova && config.cordova.reloadUrl &&


### PR DESCRIPTION
`1.0.3` errors for me within the `in-app-livereload` instance initializer.

> TypeError: app.container.lookupFactory is not a function. (In 'app.container.lookupFactory('config:environment')', 'app.container.lookupFactory' is undefined)

I'm running ember  `2.5.1` in an iOS 9.3 iPad 2 simulator.

I think the `container.lookupFactory` public API may have been removed in newer versions of ember.

Using `resolveRegistration` works well for my setup, but it may not work so well in older versions of ember. Note that the old `__container__.lookupFactory` that was altered in #26 also still works for me.