### PR TITLE
initialize buildCommand so its not undefined when there are no buildO…

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -9,7 +9,7 @@ var linkEnv     = require('../tasks/link-environment');
 
 module.exports = Task.extend({
   run: function() {
-    var buildCommand;
+    var buildCommand = '';
     if (this.buildOptions) {
       buildCommand = this.buildOptions + ' ';
     }


### PR DESCRIPTION
When running ember cdv:build --platform android `cordova.js` was never included.

I tracked it down to the fact that build task [tries to concatenate](https://github.com/isleofcode/ember-cordova/blob/4051805306f5d2ba040e285e34e59733340a4167/lib/tasks/build.js#L16) to the buildCommand string. This results in `undefined EMBER_CORDOVA=true....`.

PR initialises the buildCommand to an empty string so it's not undefined when there are no buildOptions defined.

