### PR TITLE
Added support to browser platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ As a final step, add your desired platforms, e.g.:
 ```
 ember cdv platform add ios
 ember cdv platform add android
+ember cdv platform add browser #experimental
 ```
 
 Cordova working relies on the cordova.js script being injected. By default, this happens using ember cdv commands. Your vanilla ember build && ember s commands will not inject cordova.js by design.
+
+### A note on browser platform
+
+Some cordova/phonegap plugins have browser fallbacks. For example [phonegap-plugin-barcodescanner](https://github.com/phonegap/phonegap-plugin-barcodescanner) will ask you to manually type the barcode value. Using the browser platform, you'll be able to develop your cordova app as it was a regular ember app.
 
 ##Features and Documentation
 * [CLI](docs/cli.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,6 +75,7 @@ here](livereload.md).
 #### Examples
 + `ember cdv:serve`
 + `ember cordova:serve --platform=android --reloadUrl=192.168.1.1`
++ `ember cdv:serve --platform=browser --env "development"`
 
 ## Cordova
 

--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@ module.exports = {
         pluginsPath = path.join(platformsPath, 'ios', 'www');
       } else if (platform === 'android') {
         pluginsPath = path.join(platformsPath, 'android', 'assets', 'www');
+      } else if (platform === 'browser') {
+        pluginsPath = path.join(platformsPath, 'browser', 'www');
       }
 
       var files = ['cordova.js', 'cordova_plugins.js'];


### PR DESCRIPTION
Adding support to browser platform allows the ember app to run in the browser, speeding up development. Some plugins, such as phonegap-plugin-barcodescanner, provide a browser fallback implementation