### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/tasks/prepare.js
+++ b/lib/tasks/prepare.js
@@ -8,6 +8,7 @@ var fs           = require('fs-extra');
 
 module.exports = Task.extend({
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     if (!this.project) {
       throw new Error('A project must be passed into this function');
     }


### PR DESCRIPTION
This fixes deprecation warning when trying to run ember-cordova with a newly created ember-cli 2.6.2 app