### PR TITLE
Update requirements to include installing cordova

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ greater, including 2+.
 When push comes to shove we are likely to only support Ember 2.4 or
 greater.
 
+Before you can use this addon, you will need to have Cordova's CLI installed on your machine. If you do not already have it installed, you can install it with:
+
+```
+  npm install -g cordova
+```
+
 ## Getting Started
 
 If you are migrating from ember-cli-cordova, read the [migration


### PR DESCRIPTION
Getting started with this addon, it was not clear that users needed to already have cordova's cli installed. Updating the README to include installing cordova CLI in the Platforms and Requirements Section.