### PR TITLE
fix(prepare-task): cordova-lib prepare does not need Promise.denodeify

### DIFF
--- a/lib/tasks/prepare.js
+++ b/lib/tasks/prepare.js
@@ -4,11 +4,10 @@ var Task            = require('./-task');
 var Promise         = require('ember-cli/lib/ext/promise');
 var cordovaRun      = require('../utils/cordova-run');
 var cordovaPrepare  = require('cordova-lib/src/cordova/prepare');
-var preparePromise  = Promise.denodeify(cordovaPrepare);
 
 module.exports = Task.extend({
   run: function() {
     this.ui.writeLine('Running cordova prepare');
-    return cordovaRun(preparePromise, this.project, []);
+    return cordovaRun(cordovaPrepare, this.project, []);
   }
 });


### PR DESCRIPTION
afterPrepare hook was not running, this seems like the culprit.

Perhaps the existing approach is required for older cordova versions?

Needs tests.