### PR TITLE
fix(cli): fix command-exists util(module) for windows

### DIFF
--- a/lib/utils/command-exists.js
+++ b/lib/utils/command-exists.js
@@ -2,9 +2,15 @@
 
 var childProcess = require('child_process');
 
+var isUsingWindows = process.platform == 'win32';
+
 module.exports = function(commandName) {
   var cmdStr = 'command -v ' + commandName +
     ' >/dev/null && { echo >&1 \'command found\'; }';
+
+  if(isUsingWindows) {
+    cmdStr = 'where ' + commandName;
+  }
 
   try {
     childProcess.execSync(cmdStr);


### PR DESCRIPTION
Hey I fix this issue ```  cordova-is-installed fails on Windows #152 ```. 