### PR TITLE
Loads the environment variable when serving

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -119,7 +119,7 @@ module.exports = Command.extend({
           .then(cordovaBuild.prepare(platform))
           .then(hook.prepare('afterBuild'))
           .then(function() {
-            var config = command.project.config();
+            var config = command.project.config(serveOpts.environment);
 
             _merge(serveOpts, {
               baseURL: config.baseURL || '/',


### PR DESCRIPTION
This addresses a bug where the environment flag is not respected when running `ember cdv:serve`.

It sends in the environment when loading the config file.