### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/commands/-command.js
+++ b/lib/commands/-command.js
@@ -1,7 +1,7 @@
 var Command         = require('ember-cli/lib/models/command');
 var Leek            = require('leek');
 var ConfigStore     = require('configstore');
-var uuid            = require('node-uuid');
+var uuid            = require('uuid');
 var _get            = require('lodash').get;
 
 module.exports = Command.extend({

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "fs-extra": "^0.26.5",
     "leek": "0.0.23",
     "lodash": "^4.13.1",
-    "node-uuid": "^1.4.7",
     "portfinder": "^1.0.5",
     "rimraf": "^2.5.4",
     "rsvp": "^3.2.1",
     "splicon": "0.0.6",
     "svg2png": "^3.0.0",
+    "uuid": "^3.0.0",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.