### PR TITLE
Added clarity to docs

### DIFF
--- a/pages/workflow/building.md
+++ b/pages/workflow/building.md
@@ -10,8 +10,10 @@ title:  "Building"
 To deploy to an iOS device, you must have Provisioning Profiles set up. Usually, Xcode can set up development profiles for you automatically.
 
 To run:
-`ember cdv run --platform=android --device`
-`ember cdv run --platform=ios --emulator`
+```bash
+ember cdv run --platform=ios --emulator    # Deploy to iOS simulator
+ember cdv run --platform=android --device  # Deploy to Android device
+```
 
 Alternatively `ember cdv:open` will open your project in Xcode or Android Studio. The IDE can then be used for starting emulators, code signing & app store uploads.
 

--- a/pages/workflow/hooks.md
+++ b/pages/workflow/hooks.md
@@ -12,9 +12,11 @@ The following hooks are available:
 
 Use hooks for any customization, cleanup or warnings.
 
-To create a hook, create a file at ember-cordova/hooks/hookName.js
+To create a hook, create a file at `ember-cordova/cordova/hooks/<hook_type>/hook_name.js`
+where `<hook_type>` is one of the hook types defined in the
+[Apache Cordova hook documentation](https://cordova.apache.org/docs/en/latest/guide/appdev/hooks/index.html#introduction).
 
-An example hook:
+An example javascript hook:
 
 ```js
 "use strict";
@@ -22,4 +24,17 @@ An example hook:
 module.exports = function() {
   //do something
 };
+```
+
+An example Bash hook:
+```bash
+#!/usr/bin/env bash
+# An example "after_prepare" hook
+# ember-cordova/cordova/hooks/after_prepare/echo.sh
+
+echo "Hello, World"
+
+# Capture status of our hook and exit with a proper exit code
+STATUS=$?
+exit $STATUS
 ```


### PR DESCRIPTION
* Added an example bash hook for `after_prepare`
* Added link to apache cordova project for hook docs
* Cleaned up styling of building command examples