### PR TITLE
feat(refactor): support for promises returned by hooks

### DIFF
--- a/lib/tasks/run-hook.js
+++ b/lib/tasks/run-hook.js
@@ -13,7 +13,7 @@ module.exports = Task.extend({
 
   run: function(hookName) {
     return new Promise(function(resolve, reject) {
-      var projectPath, hookPath, hook;
+      var projectPath, hookPath, hook, hookReturn;
 
       projectPath = cordovaPath(this.project, true);
       hookPath = path.join(projectPath, 'hooks', hookName + '.js');
@@ -23,11 +23,11 @@ module.exports = Task.extend({
 
         try {
           hook = require(hookPath);
+          hookReturn = hook();
 
-          hook();
-          logger.success('Ran hook for: ' + hookName);
-
-          resolve();
+          resolve(hookReturn).then(function() {
+            logger.success('Ran hook for: ' + hookName);
+          });
         } catch (e) {
           reject(e);
         }

--- a/node-tests/fixtures/ember-cordova-mock/ember-cordova/hooks/hook-promise-rejected.js
+++ b/node-tests/fixtures/ember-cordova-mock/ember-cordova/hooks/hook-promise-rejected.js
@@ -1,0 +1,7 @@
+var Promise = require('ember-cli/lib/ext/promise');
+
+module.exports = function() {
+  return Promise(function(resolve, reject) {
+    setTimeout(5, () => reject('hook rejected'));
+  });
+};

--- a/node-tests/fixtures/ember-cordova-mock/ember-cordova/hooks/hook-promise-resolved.js
+++ b/node-tests/fixtures/ember-cordova-mock/ember-cordova/hooks/hook-promise-resolved.js
@@ -1,0 +1,7 @@
+var Promise = require('ember-cli/lib/ext/promise');
+
+module.exports = function() {
+  return Promise(function(resolve, reject) {
+    setTimeout(5, () => resolve('resolved promise from hook'));
+  });
+};

--- a/node-tests/unit/tasks/run-hook-test.js
+++ b/node-tests/unit/tasks/run-hook-test.js
@@ -19,4 +19,18 @@ describe('Run Hook Task', function() {
     var hookTask = new HookTask(mockProject);
     expect(hookTask.run('invalid')).to.be.rejected;
   });
+
+  it('is resolved if the hook is resolved', function() {
+    var hookTask = new HookTask(mockProject);
+    var expectation = expect(hookTask.run('hook-promise-resolved'));
+    expectation.to.eventually.equal('hook resolved');
+    expectation.to.be.fulfilled;
+  });
+
+  it('is rejected if the hook is rejected', function() {
+    var hookTask = new HookTask(mockProject);
+    var expectation = expect(hookTask.run('hook-promise-rejected'));
+    expectation.to.eventually.equal('hook rejected');
+    expectation.to.be.rejected;
+  });
 });


### PR DESCRIPTION
For cases where developers may want to return promises from their build hooks and require that the Cordova build doesn't start until those hooks are resolved or rejected. Last night I needed hooks to edit files before builds then revert afterwards, being new to Cordova hooks I read the Cordova docs and followed their lead in making the hooks async. 

A small refactor in `lib/tasks/run-hooks.js` was required to handle promises returned from the build hooks.

Included are 2 minimal tests to show that the promises returned from hooks were handled, I tried to follow your style. I wouldn't mind lending some time towards writing larger scoped tests for the PR if someone could offer advice on how to best tackle more comprehensive test cases.