### PR TITLE
Add --skip-cordova-build to `build` command

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -30,6 +30,7 @@ module.exports = Command.extend({
     { name: 'emulator',                            type: Boolean, default: false },
     { name: 'build-config',                        type: 'Path', aliases: ['buildConfig'] },
     { name: 'force',                               type: Boolean, default: false },
+    { name: 'skip-cordova-build',                  type: Boolean, default: false},
     { name: 'skip-ember-build',                    type: Boolean, default: false},
 
     // iOS Signing Options
@@ -104,7 +105,11 @@ module.exports = Command.extend({
           return emberBuild.run();
         }
       })
-      .then(cordovaBuild.prepare())
+      .then(function() {
+        if (options.skipCordovaBuild !== true) {
+          return cordovaBuild.run();
+        }
+      })
       .then(hook.prepare('afterBuild'))
       .then(function() {
         logger.success('ember-cordova project built');

--- a/node-tests/unit/commands/build-test.js
+++ b/node-tests/unit/commands/build-test.js
@@ -131,6 +131,23 @@ describe('Build Command', function() {
         });
     });
 
+    it('skips cordova-build with the --skip-cordova-build flag', function() {
+      var build = setupBuild();
+
+      return build.run({skipCordovaBuild: true})
+        .then(function() {
+          //h-t ember-electron for the pattern
+          expect(tasks).to.deep.equal([
+            'validate-root-url',
+            'validate-allow-navigation',
+            'validate-platform',
+            'hook beforeBuild',
+            'ember-build',
+            'hook afterBuild'
+          ]);
+        });
+    });
+
     it('parses cordova build opts', function() {
       var optDouble = td.replace('../../../lib/utils/parse-cordova-build-opts');
       var build = setupBuild();


### PR DESCRIPTION
In the process of integrating with other build tools, I've come across a few situations where I want to run an ember build with Cordova assets injected, but don't need to run the actual Cordova build. This adds a `--skip-cordova-build` flag to `ember cdv:build` to match the existing `--skip-ember-build` flag.