### PR TITLE
Fix testdouble replacement leak in create-cordova-project-test

### DIFF
--- a/node-tests/unit/tasks/create-cordova-project-test.js
+++ b/node-tests/unit/tasks/create-cordova-project-test.js
@@ -72,6 +72,10 @@ describe('Cordova Create Task', function() {
   });
 
   it('raises a warning if cordova project already exists', function() {
+    // We can't replace existsSync again here without resetting the previous
+    // replacement from beforeEach. Doing so will store the beforeEach
+    // version as the "real" function and leak into other tests.
+    td.reset();
     td.replace(fsUtils, 'existsSync', function() {
       return true;
     });


### PR DESCRIPTION
I was trying to better understand the return semantics for hooks and noticed that none of my changes to the test suite hook files were causing the hook tests to fail. This led me to realize that none of the hook files were ever being loaded because `fsUtils.existsSync` had been replaced to always return false.

After this fix, I can confirm that the hook files are being run in the tests as expected. (The hook tests still don't fail when I entirely comment out the contents of all the sample hooks, but that's a separate issue…)