### PR TITLE
Pass `cdv:serve` options to build hooks

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -118,7 +118,7 @@ module.exports = Command.extend({
       .then(validateAllowNavigation.prepare(true))
       .then(validatePlatform.prepare())
       .then(validatePlugin.prepare())
-      .then(hook.prepare('beforeBuild'))
+      .then(hook.prepare('beforeBuild', options))
       .then(this._autoFindLiveReloadPort.bind(this, options))
       .then(function(serveOpts) {
 
@@ -128,7 +128,7 @@ module.exports = Command.extend({
               return cordovaBuild.run(platform);
             }
           })
-          .then(hook.prepare('afterBuild'))
+          .then(hook.prepare('afterBuild', options))
           .then(function() {
             var config = command.project.config(serveOpts.environment);
 


### PR DESCRIPTION
I just realized I'd missed the separate `beforeBuild` and `afterBuild` hook invocation that happens in the `serve` command as part of #232.