### PR TITLE
Move ember-cli out of direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "hybrid",
     "mobile"
   ],
+  "peerDependencies": {
+    "ember-cli": "^2.7.0"
+  },
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
@@ -61,7 +64,6 @@
     "configstore": "^2.0.0",
     "copy-dir": "^0.3.0",
     "cordova-lib": "^6.3.0",
-    "ember-cli": "2.9.1",
     "fs-extra": "^1.0.0",
     "leek": "0.0.24",
     "lodash": "^4.13.1",
@@ -80,6 +82,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "ember-ajax": "2.5.2",
+    "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
Replaces the ember-cli `dependencies` entry with entries in both `devDependencies` and `peerDependencies`.

Fixes #235