### PR TITLE
Add Cordova logging to cordova-raw task; pass down --verbose; fix RawTask error reporting

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -88,7 +88,8 @@ module.exports = Command.extend({
     var cordovaBuild = new CdvBuildTask({
       project: project,
       platform: platform,
-      cordovaOpts: cordovaOpts
+      cordovaOpts: cordovaOpts,
+      verbose: options.verbose
     });
 
     logger.info('ember-cordova: Building app');

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -11,11 +11,16 @@ module.exports = Command.extend({
   description: 'Runs cordova prepare and ember cdv link',
   works: 'insideProject',
 
+  availableOptions: [
+    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] }
+  ],
+
   run: function(options) {
     this._super.apply(this, arguments);
 
     var prepare = new PrepareTask({
-      project: this.project
+      project: this.project,
+      verbose: options.verbose
     });
 
     var hook = new HookTask({

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -102,7 +102,8 @@ module.exports = Command.extend({
 
     var cordovaBuild = new CdvBuildTask({
       project: this.project,
-      platform: options.platform
+      platform: options.platform,
+      verbose: options.verbose
     });
 
     var serve = new ServeTask({

--- a/lib/tasks/cordova-build.js
+++ b/lib/tasks/cordova-build.js
@@ -8,6 +8,7 @@ module.exports = Task.extend({
 
   platform: undefined,
   cordovaOpts: [],
+  verbose: false,
 
   run: function() {
     var build = new CordovaRawTask({
@@ -17,7 +18,8 @@ module.exports = Task.extend({
 
     return build.run({
       platforms: [this.platform],
-      options: this.cordovaOpts
+      options: this.cordovaOpts,
+      verbose: this.verbose
     });
   }
 });

--- a/lib/tasks/cordova-raw.js
+++ b/lib/tasks/cordova-raw.js
@@ -12,11 +12,8 @@ module.exports = Task.extend({
   project: undefined,
   rawApi: undefined,
 
-  cordovaRawPromise: function(resolve, reject) {
-    return cordovaProj.raw[this.rawApi].apply(this, arguments)
-      .catch(function(err) {
-        reject('Cordova raw error \n' + err);
-      });
+  cordovaRawPromise: function(/* rawArgs */) {
+    return cordovaProj.raw[this.rawApi].apply(this, arguments);
   },
 
   run: function() {
@@ -31,6 +28,8 @@ module.exports = Task.extend({
       this.cordovaRawPromise.apply(this, args).then(function() {
         process.chdir(emberPath);
         resolve();
+      }).catch(function(err) {
+        reject(err);
       });
     }.bind(this));
   }

--- a/lib/tasks/cordova-raw.js
+++ b/lib/tasks/cordova-raw.js
@@ -6,7 +6,7 @@ var cordovaPath     = require('../utils/cordova-path');
 var cordovaLib      = require('cordova-lib');
 var cordovaProj     = cordovaLib.cordova;
 var events          = cordovaLib.events;
-var logger          = require('cordova-common').CordovaLogger.get();
+var cordovaLogger   = require('cordova-common').CordovaLogger.get();
 
 module.exports = Task.extend({
   project: undefined,
@@ -25,8 +25,8 @@ module.exports = Task.extend({
       var emberPath = process.cwd();
       process.chdir(cordovaPath(this.project));
 
-      logger.subscribe(events);
-      if (args[0] && args[0].verbose) { logger.setLevel('verbose'); }
+      cordovaLogger.subscribe(events);
+      if (args[0] && args[0].verbose) { cordovaLogger.setLevel('verbose'); }
 
       this.cordovaRawPromise.apply(this, args).then(function() {
         process.chdir(emberPath);

--- a/lib/tasks/cordova-raw.js
+++ b/lib/tasks/cordova-raw.js
@@ -3,7 +3,10 @@
 var Task            = require('./-task');
 var Promise         = require('ember-cli/lib/ext/promise');
 var cordovaPath     = require('../utils/cordova-path');
-var cordovaProj     = require('cordova-lib').cordova;
+var cordovaLib      = require('cordova-lib');
+var cordovaProj     = cordovaLib.cordova;
+var events          = cordovaLib.events;
+var logger          = require('cordova-common').CordovaLogger.get();
 
 module.exports = Task.extend({
   project: undefined,
@@ -21,6 +24,9 @@ module.exports = Task.extend({
     return new Promise(function(resolve, reject) {
       var emberPath = process.cwd();
       process.chdir(cordovaPath(this.project));
+
+      logger.subscribe(events);
+      if (args[0] && args[0].verbose) { logger.setLevel('verbose'); }
 
       this.cordovaRawPromise.apply(this, args).then(function() {
         process.chdir(emberPath);

--- a/lib/tasks/prepare.js
+++ b/lib/tasks/prepare.js
@@ -6,6 +6,7 @@ var logger          = require('../utils/logger');
 
 module.exports = Task.extend({
   project: undefined,
+  verbose: false,
 
   run: function() {
     logger.info('Running cordova prepare');
@@ -14,6 +15,6 @@ module.exports = Task.extend({
       rawApi: 'prepare',
     });
 
-    return prepare.run();
+    return prepare.run({ verbose: this.verbose });
   }
 });

--- a/node-tests/unit/tasks/cordova-build-test.js
+++ b/node-tests/unit/tasks/cordova-build-test.js
@@ -20,7 +20,7 @@ describe('Cordova Build Task', function() {
     build.platform = 'ios';
     build.run();
 
-    td.verify(cdvBuild({platforms: ['ios'], options: []}));
+    td.verify(cdvBuild({platforms: ['ios'], options: [], verbose: false}));
   });
 
   it('sets platform to android', function() {
@@ -29,6 +29,6 @@ describe('Cordova Build Task', function() {
     build.platform = 'android';
     build.run();
 
-    td.verify(cdvBuild({platforms: ['android'], options: []}));
+    td.verify(cdvBuild({platforms: ['android'], options: [], verbose: false}));
   });
 });

--- a/node-tests/unit/tasks/cordova-raw-test.js
+++ b/node-tests/unit/tasks/cordova-raw-test.js
@@ -6,7 +6,10 @@ var expect          = require('../../helpers/expect');
 var cordovaPath     = require('../../../lib/utils/cordova-path');
 var mockProject     = require('../../fixtures/ember-cordova-mock/project');
 var Promise         = require('ember-cli/lib/ext/promise');
-var cordovaProj     = require('cordova-lib').cordova;
+var cordovaLib      = require('cordova-lib');
+var cordovaProj     = cordovaLib.cordova;
+var events          = cordovaLib.events;
+var logger          = require('cordova-common').CordovaLogger.get();
 
 describe('Cordova Raw Task', function() {
   var setupTask = function() {
@@ -59,6 +62,24 @@ describe('Cordova Raw Task', function() {
           return args
         })
       ).to.eventually.equal(emberPath);
+    });
+
+    it('sets up Cordova logging', function() {
+      td.replace(logger, 'subscribe');
+      var raw = setupTask();
+
+      return raw.run().then(function() {
+        td.verify(logger.subscribe(events));
+      });
+    });
+
+    it('logs verbosely when requested', function() {
+      td.replace(logger, 'setLevel');
+      var raw = setupTask();
+
+      return raw.run({ verbose: true }).then(function() {
+        td.verify(logger.setLevel('verbose'));
+      });
     });
   });
 });

--- a/node-tests/unit/tasks/cordova-raw-test.js
+++ b/node-tests/unit/tasks/cordova-raw-test.js
@@ -9,7 +9,7 @@ var Promise         = require('ember-cli/lib/ext/promise');
 var cordovaLib      = require('cordova-lib');
 var cordovaProj     = cordovaLib.cordova;
 var events          = cordovaLib.events;
-var logger          = require('cordova-common').CordovaLogger.get();
+var cordovaLogger   = require('cordova-common').CordovaLogger.get();
 
 describe('Cordova Raw Task', function() {
   var setupTask = function() {
@@ -65,20 +65,20 @@ describe('Cordova Raw Task', function() {
     });
 
     it('sets up Cordova logging', function() {
-      td.replace(logger, 'subscribe');
+      td.replace(cordovaLogger, 'subscribe');
       var raw = setupTask();
 
       return raw.run().then(function() {
-        td.verify(logger.subscribe(events));
+        td.verify(cordovaLogger.subscribe(events));
       });
     });
 
     it('logs verbosely when requested', function() {
-      td.replace(logger, 'setLevel');
+      td.replace(cordovaLogger, 'setLevel');
       var raw = setupTask();
 
       return raw.run({ verbose: true }).then(function() {
-        td.verify(logger.setLevel('verbose'));
+        td.verify(cordovaLogger.setLevel('verbose'));
       });
     });
   });

--- a/node-tests/unit/tasks/cordova-raw-test.js
+++ b/node-tests/unit/tasks/cordova-raw-test.js
@@ -82,4 +82,20 @@ describe('Cordova Raw Task', function() {
       });
     });
   });
+
+  describe('when the raw task fails', function() {
+    beforeEach(function() {
+      td.replace(RawTask.prototype, 'cordovaRawPromise', function() {
+        return Promise.reject(new Error('fail'));
+      });
+    });
+
+    it('rejects run() with the failure', function() {
+      var raw = setupTask();
+
+      return expect(raw.run()).to.be.rejectedWith(
+        /fail/
+      );
+    });
+  });
 });

--- a/node-tests/unit/tasks/prepare-test.js
+++ b/node-tests/unit/tasks/prepare-test.js
@@ -19,6 +19,6 @@ describe('Prepare Task', function() {
     var prepare = setupPrepareTask();
     prepare.run();
 
-    td.verify(rawDouble());
+    td.verify(rawDouble({ verbose: false }));
   });
 });

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "configstore": "^2.0.0",
     "copy-dir": "^0.3.0",
     "cordova-lib": "^6.3.0",
+    "cordova-common": "^1.5.0",
     "fs-extra": "^1.0.0",
     "leek": "0.0.24",
     "lodash": "^4.13.1",


### PR DESCRIPTION
I realized that `ember cdv build --verbose` was giving me a bunch more output than `ember cdv:build --verbose`, so I dug around a bit. This sets up a `CordovaLogger` subscribed to log events in a similar way that the cordova CLI itself does. 

Fixes #144