### PR TITLE
Do not validate platform if skipping Cordova build

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -99,7 +99,11 @@ module.exports = Command.extend({
     return validateRootUrl.run(projectConfig, options.force)
       .then(validateLocationType.prepare(projectConfig))
       .then(validateAllowNavigation.prepare(false))
-      .then(validatePlatform.prepare())
+      .then(function() {
+        if (options.skipCordovaBuild !== true) {
+          return validatePlatform.prepare();
+        }
+      })
       .then(hook.prepare('beforeBuild', options))
       .then(function() {
         if (options.skipEmberBuild !== true) {

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -99,9 +99,9 @@ module.exports = Command.extend({
     return validateRootUrl.run(projectConfig, options.force)
       .then(validateLocationType.prepare(projectConfig))
       .then(validateAllowNavigation.prepare(false))
-      .then(function() {
+      .then(function(result) {
         if (options.skipCordovaBuild !== true) {
-          return validatePlatform.prepare();
+          validatePlatform.run();
         }
       })
       .then(hook.prepare('beforeBuild', options))

--- a/node-tests/unit/commands/build-test.js
+++ b/node-tests/unit/commands/build-test.js
@@ -140,7 +140,6 @@ describe('Build Command', function() {
           expect(tasks).to.deep.equal([
             'validate-root-url',
             'validate-allow-navigation',
-            'validate-platform',
             'hook beforeBuild',
             'ember-build',
             'hook afterBuild'


### PR DESCRIPTION
I am attempting to set up hot code pushing and have the build and deployment process as part of CI.  As a result, I need to just build the Ember app without building the Cordova app and without having all of the Cordova platform / configuration / environment available.  The `--skip-cordova-build` option is great, but currently it still validates the platform and fails if it is not set up.  This platform validation seems unnecessary in this use case, and it is preventing the plain old Ember build from occurring.  The proposed change simply bypasses the platform validation when skipping the Cordova build.