### PR TITLE
Feat/verbose logging

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,14 @@ insted of`cordova`, for example `ember cdv:{command}`.
 You can pass a command to cordova without
 ember-cordova interference with ember cdv build, vs. ember cdv:build.
 
+Enable verbose logging by prefixing your command with `DEBUG=$scope`, where
+`$scope` is one of:
+
+- `cordova`, to include log output from cordova-lib (e.g. cdv build phase);
+- `ember-cli`, to include log output from e-cli (e.g. ember build phase); or
+- `*`, to include cdv + e-cli log output, plus all other available
+  [heimdalljs-logger](https://github.com/heimdalljs/heimdalljs-logger) trees
+
 ### Available Commands
 * ember cdv:open
 * ember cdv:build

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -23,7 +23,6 @@ module.exports = Command.extend({
   /* eslint-disable max-len */
   availableOptions: [
     { name: 'platform',                            type: String,  default: 'ios' },
-    { name: 'verbose',                             type: Boolean, default: false,                       aliases: ['v'] },
     { name: 'environment',                         type: String,  default: 'development',               aliases: ['e', 'env', { 'dev': 'development' }, { 'prod': 'production' }] },
     { name: 'cordova-output-path',                 type: 'Path',  default: 'ember-cordova/cordova/www', aliases: ['op', 'out'] },
     { name: 'release',                             type: Boolean, default: false },

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -11,10 +11,6 @@ module.exports = Command.extend({
   description: 'Runs cordova prepare and ember cdv link',
   works: 'insideProject',
 
-  availableOptions: [
-    { name: 'verbose', type: Boolean, default: false, aliases: ['v'] }
-  ],
-
   run: function(options) {
     this._super.apply(this, arguments);
 

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -37,7 +37,6 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'platform',             type: String,  default: 'ios' },
     { name: 'reload-url',           type: String,                          aliases: ['r'] },
-    { name: 'verbose',              type: Boolean, default: false,         aliases: ['v'] },
     { name: 'port',                 type: Number,  default: defaultPort,   aliases: ['p'] },
     { name: 'host',                 type: String,                          aliases: ['H'],     description: 'Listens on all interfaces by default' },
     { name: 'proxy',                type: String,                          aliases: ['pr', 'pxy'] },

--- a/lib/tasks/cordova-build.js
+++ b/lib/tasks/cordova-build.js
@@ -8,7 +8,6 @@ module.exports = Task.extend({
 
   platform: undefined,
   cordovaOpts: [],
-  verbose: false,
 
   run: function() {
     var build = new CordovaRawTask({
@@ -18,8 +17,7 @@ module.exports = Task.extend({
 
     return build.run({
       platforms: [this.platform],
-      options: this.cordovaOpts,
-      verbose: this.verbose
+      options: this.cordovaOpts
     });
   }
 });

--- a/lib/tasks/cordova-raw.js
+++ b/lib/tasks/cordova-raw.js
@@ -7,6 +7,8 @@ var cordovaProj     = cordovaLib.cordova;
 var events          = cordovaLib.events;
 var cordovaLogger   = require('cordova-common').CordovaLogger.get();
 
+var isSubscribed    = false;
+
 module.exports = Task.extend({
   project: undefined,
   rawApi: undefined,
@@ -21,7 +23,11 @@ module.exports = Task.extend({
     var debug = process.env.DEBUG;
 
     process.chdir(cordovaPath(this.project));
-    cordovaLogger.subscribe(events);
+
+    if (!isSubscribed) {
+      cordovaLogger.subscribe(events);
+      isSubscribed = true;
+    }
 
     if (debug && (debug === '*' || debug.indexOf('cordova') > -1)) {
       cordovaLogger.setLevel('verbose');

--- a/lib/tasks/cordova-raw.js
+++ b/lib/tasks/cordova-raw.js
@@ -7,9 +7,7 @@ var cordovaProj     = cordovaLib.cordova;
 var events          = cordovaLib.events;
 var cordovaLogger   = require('cordova-common').CordovaLogger.get();
 
-var isSubscribed    = false;
-
-module.exports = Task.extend({
+var CordovaRawTask = Task.extend({
   project: undefined,
   rawApi: undefined,
 
@@ -28,9 +26,9 @@ module.exports = Task.extend({
 
     process.chdir(cordovaPath(this.project));
 
-    if (isLoggingCordova && !isSubscribed) {
+    if (isLoggingCordova && !CordovaRawTask.isSubscribedToLogs) {
       cordovaLogger.subscribe(events);
-      isSubscribed = true;
+      CordovaRawTask.isSubscribedToLogs = true;
     }
 
     if (isLoggingCordova && process.env.DEBUG_LEVEL === 'trace') {
@@ -43,3 +41,7 @@ module.exports = Task.extend({
       });
   }
 });
+
+CordovaRawTask.isSubscribedToLogs = false;
+
+module.exports = CordovaRawTask;

--- a/lib/tasks/cordova-raw.js
+++ b/lib/tasks/cordova-raw.js
@@ -21,15 +21,19 @@ module.exports = Task.extend({
     var args = arguments;
     var emberPath = process.cwd();
     var debug = process.env.DEBUG;
+    var isLoggingCordova = debug && (
+      debug === '*' ||
+      debug.indexOf('cordova') > -1
+    )
 
     process.chdir(cordovaPath(this.project));
 
-    if (!isSubscribed) {
+    if (isLoggingCordova && !isSubscribed) {
       cordovaLogger.subscribe(events);
       isSubscribed = true;
     }
 
-    if (debug && (debug === '*' || debug.indexOf('cordova') > -1)) {
+    if (isLoggingCordova && process.env.DEBUG_LEVEL === 'trace') {
       cordovaLogger.setLevel('verbose');
     }
 

--- a/lib/tasks/cordova-raw.js
+++ b/lib/tasks/cordova-raw.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Task            = require('./-task');
-var Promise         = require('ember-cli/lib/ext/promise');
 var cordovaPath     = require('../utils/cordova-path');
 var cordovaLib      = require('cordova-lib');
 var cordovaProj     = cordovaLib.cordova;
@@ -18,19 +17,19 @@ module.exports = Task.extend({
 
   run: function() {
     var args = arguments;
-    return new Promise(function(resolve, reject) {
-      var emberPath = process.cwd();
-      process.chdir(cordovaPath(this.project));
+    var emberPath = process.cwd();
+    var debug = process.env.DEBUG;
 
-      cordovaLogger.subscribe(events);
-      if (args[0] && args[0].verbose) { cordovaLogger.setLevel('verbose'); }
+    process.chdir(cordovaPath(this.project));
+    cordovaLogger.subscribe(events);
 
-      this.cordovaRawPromise.apply(this, args).then(function() {
+    if (debug && (debug === '*' || debug.indexOf('cordova') > -1)) {
+      cordovaLogger.setLevel('verbose');
+    }
+
+    return this.cordovaRawPromise.apply(this, args)
+      .then(function() {
         process.chdir(emberPath);
-        resolve();
-      }).catch(function(err) {
-        reject(err);
       });
-    }.bind(this));
   }
 });

--- a/lib/tasks/create-livereload-shell.js
+++ b/lib/tasks/create-livereload-shell.js
@@ -29,10 +29,10 @@ module.exports = Task.extend({
   },
 
   run: function(port, reloadUrl) {
-    return new Promise(function(resolve, reject) {
-      var project = this.project;
+    var project = this.project;
 
-      this.getShellTemplate().then(function(html) {
+    return this.getShellTemplate()
+      .then(function(html) {
         var outputPath = path.join(cordovaPath(project), 'www/index.html');
         if (reloadUrl === undefined) {
           //Replace {{liveReloadUrl}} with address
@@ -40,13 +40,11 @@ module.exports = Task.extend({
           reloadUrl = 'http://' + networkAddress + ':' + port;
         }
 
-        this.createShell(outputPath, html, reloadUrl).then(resolve);
-
+        return this.createShell(outputPath, html, reloadUrl)
       }.bind(this))
       .catch(function(err) {
-        reject('Error moving index.html for livereload ' + err);
+        return Promise.reject('Error moving index.html for livereload ' + err);
       });
-    }.bind(this));
   }
 });
 

--- a/lib/tasks/open-app.js
+++ b/lib/tasks/open-app.js
@@ -15,34 +15,32 @@ module.exports = Task.extend({
   project: undefined,
 
   run: function() {
-    return new Promise(function(resolve, reject) {
-      var projectPath, open, command;
-      var cdvPath = cordovaPath(this.project);
+    var projectPath, open, command;
+    var cdvPath = cordovaPath(this.project);
 
-      if (this.platform === 'ios') {
-        projectPath = path.join(cdvPath, 'platforms/ios/*.xcodeproj');
+    if (this.platform === 'ios') {
+      projectPath = path.join(cdvPath, 'platforms/ios/*.xcodeproj');
 
-      } else if (this.platform === 'android') {
-        projectPath = path.join(cdvPath, 'platforms/android/.project');
+    } else if (this.platform === 'android') {
+      projectPath = path.join(cdvPath, 'platforms/android/.project');
 
-      } else {
-        reject(
-          'The ' + this.platform +
-          ' platform is not supported. Please use \'ios\' or \'android\''
-        );
+    } else {
+      return Promise.reject(
+        'The ' + this.platform +
+        ' platform is not supported. Please use \'ios\' or \'android\''
+      );
+    }
+
+    logger.success('Opening app for ' + this.platform);
+
+    command = getOpenCommand(projectPath, this.application);
+    open = new BashTask({
+      command: command,
+      options: {
+        cwd: this.project.root
       }
+    });
 
-      logger.success('Opening app for ' + this.platform);
-
-      command = getOpenCommand(projectPath, this.application);
-      open = new BashTask({
-        command: command,
-        options: {
-          cwd: this.project.root
-        }
-      });
-
-      open.run().then(resolve);
-    }.bind(this));
+    return open.run();
   }
 });

--- a/lib/tasks/prepare.js
+++ b/lib/tasks/prepare.js
@@ -6,7 +6,6 @@ var logger          = require('../utils/logger');
 
 module.exports = Task.extend({
   project: undefined,
-  verbose: false,
 
   run: function() {
     logger.info('Running cordova prepare');
@@ -15,6 +14,6 @@ module.exports = Task.extend({
       rawApi: 'prepare',
     });
 
-    return prepare.run({ verbose: this.verbose });
+    return prepare.run();
   }
 });

--- a/lib/tasks/run-hook.js
+++ b/lib/tasks/run-hook.js
@@ -12,29 +12,27 @@ module.exports = Task.extend({
   project: undefined,
 
   run: function(hookName, options) {
-    return new Promise(function(resolve, reject) {
-      var projectPath, hookPath, hook, hookReturn;
+    var projectPath, hookPath, hook, hookReturn;
 
-      projectPath = cordovaPath(this.project, true);
-      hookPath = path.join(projectPath, 'hooks', hookName + '.js');
+    projectPath = cordovaPath(this.project, true);
+    hookPath = path.join(projectPath, 'hooks', hookName + '.js');
 
-      if (fsUtils.existsSync(hookPath)) {
-        logger.info('Located hook for: ' + hookName);
+    if (fsUtils.existsSync(hookPath)) {
+      logger.info('Located hook for: ' + hookName);
 
-        try {
-          hook = require(hookPath);
-          hookReturn = hook(options);
+      try {
+        hook = require(hookPath);
+        hookReturn = hook(options);
 
-          resolve(hookReturn).then(function() {
-            logger.success('Ran hook for: ' + hookName);
-          });
-        } catch (e) {
-          reject(e);
-        }
+        logger.success('Ran hook for: ' + hookName);
 
-      } else {
-        resolve();
+        return Promise.resolve(hookReturn);
+      } catch (e) {
+        return Promise.reject(e);
       }
-    }.bind(this));
+
+    } else {
+      return Promise.resolve();
+    }
   }
 });

--- a/lib/tasks/update-gitignore.js
+++ b/lib/tasks/update-gitignore.js
@@ -13,29 +13,26 @@ module.exports = Task.extend({
   project: undefined,
 
   run: function() {
-    return new Promise(function(resolve, reject) {
-      logger.info('ember-cordova: updating .gitignore');
+    logger.info('ember-cordova: updating .gitignore');
 
-      var ignoreContent = '\n';
-      ignoreContent += 'ember-cordova/tmp-livereload\n';
+    var ignoreContent = '\n';
+    ignoreContent += 'ember-cordova/tmp-livereload\n';
 
-      var itemsLength = ignorePaths.length;
-      while (itemsLength--) {
-        var item = ignorePaths[itemsLength];
-        ignoreContent += item + '*\n';
+    var itemsLength = ignorePaths.length;
+    while (itemsLength--) {
+      var item = ignorePaths[itemsLength];
+      ignoreContent += item + '*\n';
 
-        var gitkeepPath = item + '.gitkeep';
-        ignoreContent += '!' + gitkeepPath + '\n';
+      var gitkeepPath = item + '.gitkeep';
+      ignoreContent += '!' + gitkeepPath + '\n';
 
-        //create empty .gitkeep
-        fsUtils.write(gitkeepPath, '', { encoding: 'utf8' });
-      }
+      //create empty .gitkeep
+      fsUtils.write(gitkeepPath, '', { encoding: 'utf8' });
+    }
 
-      fsUtils.append('.gitignore', ignoreContent)
-        .then(resolve)
-        .catch(function(err) {
-          reject('failed to update .gitignore, err: ' + err);
-        })
-    });
+    return fsUtils.append('.gitignore', ignoreContent)
+      .catch(function(err) {
+        return Promise.reject('failed to update .gitignore, err: ' + err);
+      })
   }
 });

--- a/lib/tasks/update-watchman-config.js
+++ b/lib/tasks/update-watchman-config.js
@@ -12,12 +12,12 @@ module.exports = Task.extend({
 
   run: function() {
     var projectRoot = this.project.root;
-    return new Promise(function(resolve, reject) {
-      logger.info('ember-cordova: updating .watchmanconfig');
+    logger.info('ember-cordova: updating .watchmanconfig');
 
-      var configPath = path.join(projectRoot, '.watchmanconfig')
+    var configPath = path.join(projectRoot, '.watchmanconfig')
 
-      fsUtils.read(configPath, { encoding: 'utf8' }).then(function(config) {
+    return fsUtils.read(configPath, { encoding: 'utf8' })
+      .then(function(config) {
         var json = JSON.parse(config);
         var ignored;
 
@@ -27,19 +27,19 @@ module.exports = Task.extend({
         } else {
           ignored = ['ember-cordova'];
         }
+
         json.ignore_dirs = ignored;
 
         var contents = JSON.stringify(json);
 
-        fsUtils.write(configPath, contents, 'utf8').then(function() {
-          logger.success('Added ember-cordova to watchman ignore');
-          resolve();
-        });
+        return fsUtils.write(configPath, contents, 'utf8')
+          .then(function() {
+            logger.success('Added ember-cordova to watchman ignore');
+          });
       }, function(err) {
-        reject(
+        return Promise.reject(
           'ember-cordova: failed to update .watchmanconfig, err: ' + err
         );
       });
-    });
   }
 });

--- a/lib/tasks/validate/allow-navigation.js
+++ b/lib/tasks/validate/allow-navigation.js
@@ -62,10 +62,12 @@ module.exports = Task.extend({
   validateNavigationProp: validateNavigationProp,
 
   run: function() {
-    return new Promise(function(resolve, reject) {
-      if (this.platform === 'browser') { resolve(); }
+    if (this.platform === 'browser') {
+      return Promise.resolve();
+    }
 
-      getCordovaConfig(this.project).then(function(config) {
+    return getCordovaConfig(this.project)
+      .then(function(config) {
         var livereloadProp = this.livereloadProp(
           config.widget,
           'allow-navigation',
@@ -81,11 +83,8 @@ module.exports = Task.extend({
         }
 
         if (this.rejectIfUndefined && livereloadProp === undefined) {
-          reject(LIVE_RELOAD_CONFIG_NEEDED);
+          return Promise.reject(LIVE_RELOAD_CONFIG_NEEDED);
         }
-
-        resolve();
       }.bind(this));
-    }.bind(this));
   }
 });

--- a/lib/tasks/validate/cordova-installed.js
+++ b/lib/tasks/validate/cordova-installed.js
@@ -19,14 +19,12 @@ module.exports = Task.extend({
       return Promise.resolve();
     }
 
-    return new Promise(function(resolve, reject) {
-      var result = commandExists('cordova');
+    var result = commandExists('cordova');
 
-      if (result) {
-        resolve();
-      }
+    if (result) {
+      return Promise.resolve();
+    }
 
-      reject(cordovaInstallText);
-    });
+    return Promise.reject(cordovaInstallText);
   }
 });

--- a/lib/tasks/validate/location-type.js
+++ b/lib/tasks/validate/location-type.js
@@ -11,16 +11,13 @@ module.exports = Task.extend({
 
   run: function() {
     var config = this.config;
+    var locationType    = config.locationType;
+    var isHashLocation  = locationType === 'hash';
 
-    return new Promise(function(resolve, reject) {
-      var locationType    = config.locationType;
-      var isHashLocation  = locationType === 'hash';
+    if (!isHashLocation) {
+      return Promise.reject(MUST_SPECIFY_HASH);
+    }
 
-      if (!isHashLocation) {
-        reject(MUST_SPECIFY_HASH);
-      }
-
-      resolve();
-    });
+    return Promise.resolve();
   }
 });

--- a/lib/tasks/validate/root-url.js
+++ b/lib/tasks/validate/root-url.js
@@ -32,22 +32,20 @@ module.exports = Task.extend({
   },
 
   run: function() {
-    return new Promise(function(resolve, reject) {
-      var rootProps = ['baseURL', 'rootURL', 'baseUrl', 'rootUrl'];
-      var rootValues = values(pick(this.config, rootProps));
-      var validRoot = this.validRootValues(rootValues);
+    var rootProps = ['baseURL', 'rootURL', 'baseUrl', 'rootUrl'];
+    var rootValues = values(pick(this.config, rootProps));
+    var validRoot = this.validRootValues(rootValues);
 
-      if (validRoot === false) {
-        if (this.force === true) {
-          var msg = URL_MSG + 'You have passed the --force flag, so continuing';
-          logger.warn(msg);
-          resolve();
-        } else {
-          reject(URL_MSG);
-        }
+    if (validRoot === false) {
+      if (this.force === true) {
+        var msg = URL_MSG + 'You have passed the --force flag, so continuing';
+        logger.warn(msg);
+        return Promise.resolve();
       } else {
-        resolve();
+        return Promise.reject(URL_MSG);
       }
-    }.bind(this));
+    } else {
+      return Promise.resolve();
+    }
   }
 });

--- a/lib/tasks/validate/sanitize-addon-args.js
+++ b/lib/tasks/validate/sanitize-addon-args.js
@@ -55,25 +55,24 @@ module.exports = Task.extend({
   },
 
   run: function() {
-    return new Promise(function(resolve, reject) {
-      var action, targetName, sanitized;
+    var action, targetName, sanitized;
 
-      action = this.getAction(this.rawArgs);
-      if (!action) {
-        reject('Missing add/rm flag, e.g. ember cdv:' + this.api + ' add ios');
-      }
+    action = this.getAction(this.rawArgs);
+    if (!action) {
+      var cmd = 'ember cdv:' + this.api + ' add ios'
+      return Promise.reject('Missing add/rm flag, e.g. ' + cmd);
+    }
 
-      //Cooerce rawArgs/Opts to cordova spec
-      targetName = this.getTargetName(this.rawArgs);
-      var hashedOpts = this.hashifyVars(this.varOpts);
+    //Cooerce rawArgs/Opts to cordova spec
+    targetName = this.getTargetName(this.rawArgs);
+    var hashedOpts = this.hashifyVars(this.varOpts);
 
-      sanitized = {
-        action: action,
-        name: targetName,
-        varOpts: hashedOpts
-      };
+    sanitized = {
+      action: action,
+      name: targetName,
+      varOpts: hashedOpts
+    };
 
-      resolve(sanitized);
-    }.bind(this));
+    return Promise.resolve(sanitized);
   }
 });

--- a/lib/utils/cordova-validator.js
+++ b/lib/utils/cordova-validator.js
@@ -59,77 +59,73 @@ CordovaValidator.prototype.makeError = function(error) {
 
 CordovaValidator.prototype.validateCordovaConfig = function() {
   var validator = this;
-  return new Promise(function(resolve, reject) {
-    getCordovaConfig(validator.project).then(function(cordovaConfig) {
+
+  return getCordovaConfig(validator.project)
+    .then(function(cordovaConfig) {
       if (!hasByName(cordovaConfig, validator.desiredKeyName, validator.type)) {
-        reject(validator.makeError(NOT_IN_CONFIGXML));
+        return Promise.reject(validator.makeError(NOT_IN_CONFIGXML));
       } else {
-        resolve();
+        return Promise.resolve();
       }
     });
-  });
 };
 
 CordovaValidator.prototype.validateCordovaJSON = function() {
   var validator = this;
-  return new Promise(function(resolve, reject) {
-    var cordovaPath = getCordovaPath(validator.project);
-    var fetchPath = path.join(cordovaPath, validator.jsonPath);
+  var cordovaPath = getCordovaPath(validator.project);
+  var fetchPath = path.join(cordovaPath, validator.jsonPath);
 
-    try {
-      var fetchJSON = require(fetchPath);
-      var items = Object.keys(fetchJSON);
+  try {
+    var fetchJSON = require(fetchPath);
+    var items = Object.keys(fetchJSON);
 
-      if (items.indexOf(validator.desiredKeyName) < 0) {
-        reject(validator.makeError(NOT_IN_FETCHJSON));
-      }
-      resolve();
-    } catch (e) {
-      reject(validator.makeError(NOT_IN_FETCHJSON));
+    if (items.indexOf(validator.desiredKeyName) < 0) {
+      return Promise.reject(validator.makeError(NOT_IN_FETCHJSON));
     }
-  });
+
+    return Promise.resolve();
+  } catch (e) {
+    return Promise.reject(validator.makeError(NOT_IN_FETCHJSON));
+  }
 };
 
 //Is only run for plugins, there is no equivalent for platform
 CordovaValidator.prototype.validatePluginJSON = function() {
   var validator = this;
-  return new Promise(function(resolve, reject) {
-    var cordovaPath = getCordovaPath(validator.project);
-    var platformPath = path.join(
-      cordovaPath,
-      'plugins/' + validator.platform + '.json'
-    );
+  var cordovaPath = getCordovaPath(validator.project);
+  var platformPath = path.join(
+    cordovaPath,
+    'plugins/' + validator.platform + '.json'
+  );
 
-    try {
-      var platformJSON = require(platformPath);
-      var plugins = Object.keys(platformJSON.installed_plugins);
+  try {
+    var platformJSON = require(platformPath);
+    var plugins = Object.keys(platformJSON.installed_plugins);
 
-      if (plugins.indexOf(validator.desiredKeyName) < 0) {
-        reject(validator.makeError(NOT_IN_PLATFORMJSON));
-      }
-      resolve();
-    } catch (e) {
-      reject(validator.makeError(NOT_IN_PLATFORMJSON));
+    if (plugins.indexOf(validator.desiredKeyName) < 0) {
+      return Promise.reject(validator.makeError(NOT_IN_PLATFORMJSON));
     }
-  });
+
+    return Promise.resolve();
+  } catch (e) {
+    return Promise.reject(validator.makeError(NOT_IN_PLATFORMJSON));
+  }
 };
 
 CordovaValidator.prototype.validateDirExists = function() {
   var validator = this;
-  return new Promise(function(resolve, reject) {
-    var cordovaPath = getCordovaPath(validator.project);
-    var filePath = path.join(
-      cordovaPath,
-      validator.dir,
-      validator.desiredKeyName
-    );
+  var cordovaPath = getCordovaPath(validator.project);
+  var filePath = path.join(
+    cordovaPath,
+    validator.dir,
+    validator.desiredKeyName
+  );
 
-    if (fsUtils.existsSync(filePath)) {
-      resolve();
-    } else {
-      reject(validator.makeError(NOT_IN_DIR));
-    }
-  });
+  if (fsUtils.existsSync(filePath)) {
+    return Promise.resolve();
+  } else {
+    return Promise.reject(validator.makeError(NOT_IN_DIR));
+  }
 };
 
 module.exports = CordovaValidator;

--- a/node-tests/unit/tasks/cordova-build-test.js
+++ b/node-tests/unit/tasks/cordova-build-test.js
@@ -20,7 +20,7 @@ describe('Cordova Build Task', function() {
     build.platform = 'ios';
     build.run();
 
-    td.verify(cdvBuild({platforms: ['ios'], options: [], verbose: false}));
+    td.verify(cdvBuild({platforms: ['ios'], options: []}));
   });
 
   it('sets platform to android', function() {
@@ -29,6 +29,6 @@ describe('Cordova Build Task', function() {
     build.platform = 'android';
     build.run();
 
-    td.verify(cdvBuild({platforms: ['android'], options: [], verbose: false}));
+    td.verify(cdvBuild({platforms: ['android'], options: []}));
   });
 });

--- a/node-tests/unit/tasks/cordova-raw-test.js
+++ b/node-tests/unit/tasks/cordova-raw-test.js
@@ -23,13 +23,19 @@ describe('Cordova Raw Task', function() {
     td.reset();
   });
 
-  it('attempts to run a raw cordova call', function(done) {
+  it('sets up cdv logging and attempts a raw cordova call', function(done) {
+    // n.b. need these together & at the top of file due to de-duplication of
+    // `cordovaLogger.subscribe` calls on require
+    td.replace(cordovaLogger, 'subscribe');
     td.replace(cordovaProj.raw, 'platform', function() {
       done();
     });
 
     var raw = setupTask();
-    return raw.run();
+
+    return raw.run().then(function() {
+      td.verify(cordovaLogger.subscribe(events));
+    });
   });
 
   describe('with a mock function', function() {
@@ -62,15 +68,6 @@ describe('Cordova Raw Task', function() {
           return args
         })
       ).to.eventually.equal(emberPath);
-    });
-
-    it('sets up Cordova logging', function() {
-      td.replace(cordovaLogger, 'subscribe');
-      var raw = setupTask();
-
-      return raw.run().then(function() {
-        td.verify(cordovaLogger.subscribe(events));
-      });
     });
 
     describe('verbosity', function() {

--- a/node-tests/unit/tasks/cordova-raw-test.js
+++ b/node-tests/unit/tasks/cordova-raw-test.js
@@ -7,35 +7,22 @@ var cordovaPath     = require('../../../lib/utils/cordova-path');
 var mockProject     = require('../../fixtures/ember-cordova-mock/project');
 var Promise         = require('ember-cli/lib/ext/promise');
 var cordovaLib      = require('cordova-lib');
-var cordovaProj     = cordovaLib.cordova;
-var events          = cordovaLib.events;
 var cordovaLogger   = require('cordova-common').CordovaLogger.get();
 
 describe('Cordova Raw Task', function() {
-  var setupTask = function() {
-    return new RawTask({
+  var rawTask;
+
+  beforeEach(function() {
+    rawTask = new RawTask({
       rawApi: 'platform',
       project: mockProject.project
     });
-  };
-
-  afterEach(function() {
-    td.reset();
   });
 
-  it('sets up cdv logging and attempts a raw cordova call', function(done) {
-    // n.b. need these together & at the top of file due to de-duplication of
-    // `cordovaLogger.subscribe` calls on require
-    td.replace(cordovaLogger, 'subscribe');
-    td.replace(cordovaProj.raw, 'platform', function() {
-      done();
-    });
-
-    var raw = setupTask();
-
-    return raw.run().then(function() {
-      td.verify(cordovaLogger.subscribe(events));
-    });
+  afterEach(function() {
+    rawTask = null;
+    RawTask.isSubscribedToLogs = false;
+    td.reset();
   });
 
   describe('with a mock function', function() {
@@ -51,19 +38,17 @@ describe('Cordova Raw Task', function() {
 
     it('changes to cordova dir', function() {
       var cdvPath = cordovaPath(mockProject.project);
-      var raw = setupTask();
 
-      return raw.run().then(function() {
+      return rawTask.run().then(function() {
         td.verify(chdirDouble(cdvPath));
       });
     });
 
     it('changes back to ember dir on compvarion', function() {
       var emberPath = process.cwd();
-      var raw = setupTask();
 
       return expect(
-        raw.run().then(function() {
+        rawTask.run().then(function() {
           var args = td.explain(chdirDouble).calls[1].args[0];
           return args
         })
@@ -71,49 +56,62 @@ describe('Cordova Raw Task', function() {
     });
 
     describe('verbosity', function() {
-      var raw;
-      var setDebug = function setDebug(term) {
-        var cachedDebug = process.env.DEBUG;
+      ['cordova', '*'].forEach(function(debugGroup) {
+        context('when env DEBUG = ' + debugGroup, function() {
+          var cachedDebug;
 
-        before(function() {
-          process.env.DEBUG = term;
-        });
-
-        after(function() {
-          process.env.DEBUG = cachedDebug;
-        });
-      }
-
-      beforeEach(function() {
-        td.replace(cordovaLogger, 'setLevel');
-        raw = setupTask();
-      });
-
-      context('when env DEBUG = cordova', function() {
-        setDebug('cordova');
-
-        it('logs verbosely', function() {
-          return raw.run().then(function() {
-            td.verify(cordovaLogger.setLevel('verbose'));
+          before(function() {
+            cachedDebug = process.env.DEBUG;
+            process.env.DEBUG = debugGroup;
           });
-        });
-      });
 
-      context('when env DEBUG = *', function() {
-        setDebug('*');
+          after(function() {
+            process.env.DEBUG = cachedDebug;
+          });
 
-        it('logs verbosely', function() {
-          return raw.run().then(function() {
-            td.verify(cordovaLogger.setLevel('verbose'));
+          beforeEach(function() {
+            td.replace(cordovaLogger, 'setLevel');
+            td.replace(cordovaLogger, 'subscribe');
+          });
+
+          context('and DEBUG_LEVEL !== trace', function() {
+            it('sets up cdv logging', function() {
+              return rawTask.run().then(function() {
+                td.verify(cordovaLogger.subscribe(cordovaLib.events));
+              });
+            });
+          });
+
+          context('and DEBUG_LEVEL === trace', function() {
+            var cachedDebugLevel;
+
+            before(function() {
+              cachedDebugLevel = process.env.DEBUG_LEVEL;
+              process.env.DEBUG_LEVEL = 'trace';
+            });
+
+            after(function() {
+              process.env.DEBUG_LEVEL = cachedDebugLevel;
+            });
+
+            it('sets up cdv logging', function() {
+              return rawTask.run().then(function() {
+                td.verify(cordovaLogger.subscribe(cordovaLib.events));
+              });
+            });
+
+            it('logs verbosely', function() {
+              return rawTask.run().then(function() {
+                td.verify(cordovaLogger.setLevel('verbose'));
+              });
+            });
           });
         });
       });
 
       context('when env DEBUG = undefined', function() {
-        setDebug(undefined);
-
         it('does not log verbosely', function() {
-          return raw.run().then(function() {
+          return rawTask.run().then(function() {
             td.verify(cordovaLogger.setLevel(), {
               times: 0,
               ignoreExtraArgs: true
@@ -125,6 +123,17 @@ describe('Cordova Raw Task', function() {
   });
 
   describe('when the raw task fails', function() {
+    var cachedDebug;
+
+    before(function() {
+      cachedDebug = process.env.DEBUG;
+      process.env.DEBUG = undefined;
+    });
+
+    after(function() {
+      process.env.DEBUG = cachedDebug;
+    });
+
     beforeEach(function() {
       td.replace(RawTask.prototype, 'cordovaRawPromise', function() {
         return Promise.reject(new Error('fail'));
@@ -132,9 +141,7 @@ describe('Cordova Raw Task', function() {
     });
 
     it('rejects run() with the failure', function() {
-      var raw = setupTask();
-
-      return expect(raw.run()).to.be.rejectedWith(
+      return expect(rawTask.run()).to.be.rejectedWith(
         /fail/
       );
     });

--- a/node-tests/unit/tasks/cordova-raw-test.js
+++ b/node-tests/unit/tasks/cordova-raw-test.js
@@ -73,12 +73,56 @@ describe('Cordova Raw Task', function() {
       });
     });
 
-    it('logs verbosely when requested', function() {
-      td.replace(cordovaLogger, 'setLevel');
-      var raw = setupTask();
+    describe('verbosity', function() {
+      var raw;
+      var setDebug = function setDebug(term) {
+        var cachedDebug = process.env.DEBUG;
 
-      return raw.run({ verbose: true }).then(function() {
-        td.verify(cordovaLogger.setLevel('verbose'));
+        before(function() {
+          process.env.DEBUG = term;
+        });
+
+        after(function() {
+          process.env.DEBUG = cachedDebug;
+        });
+      }
+
+      beforeEach(function() {
+        td.replace(cordovaLogger, 'setLevel');
+        raw = setupTask();
+      });
+
+      context('when env DEBUG = cordova', function() {
+        setDebug('cordova');
+
+        it('logs verbosely', function() {
+          return raw.run().then(function() {
+            td.verify(cordovaLogger.setLevel('verbose'));
+          });
+        });
+      });
+
+      context('when env DEBUG = *', function() {
+        setDebug('*');
+
+        it('logs verbosely', function() {
+          return raw.run().then(function() {
+            td.verify(cordovaLogger.setLevel('verbose'));
+          });
+        });
+      });
+
+      context('when env DEBUG = undefined', function() {
+        setDebug(undefined);
+
+        it('does not log verbosely', function() {
+          return raw.run().then(function() {
+            td.verify(cordovaLogger.setLevel(), {
+              times: 0,
+              ignoreExtraArgs: true
+            });
+          });
+        });
       });
     });
   });

--- a/node-tests/unit/tasks/prepare-test.js
+++ b/node-tests/unit/tasks/prepare-test.js
@@ -19,6 +19,6 @@ describe('Prepare Task', function() {
     var prepare = setupPrepareTask();
     prepare.run();
 
-    td.verify(rawDouble({ verbose: false }));
+    td.verify(rawDouble());
   });
 });


### PR DESCRIPTION
Adds verbose logging to ember-cordova via ember-cli standard `DEBUG` flag. Note that e-cli & cordova-lib emit logs with their own mechanisms, i.e. the logged output does not pass through `utils/logger`.

Usage:

```
DEBUG=* ember cdv:build
DEBUG=ember-cli:* ember cdv:build
DEBUG=cordova ember cdv:build
```

Alternatives considered:
- Use a `--verbose` availableOption: rejected because e-cli `Builder` did not respect a manually-set `process.env.DEBUG` param;