### PR TITLE
Document make-icons and make-splashes Default Behaviour and Platform Argument

### DIFF
--- a/pages/workflow/icon_splash_management.md
+++ b/pages/workflow/icon_splash_management.md
@@ -21,7 +21,13 @@ The source svg should be a square of any size.
 
 ## Splash Generation
 
-Place a splash.svg file at ember-cordova/splash.svg and run `ember cdv:make-splashes`. Splashes will be resized & injected.
+Place a splash.svg file at ember-cordova/splash.svg and run `ember cdv:make-splashes`. By default, splashes for all platforms will be resized & injected.
+
+To specify a single platform, use the `--platform` option with the desired platform.
+
+```
+ember cdv:make-splashes --platform ios
+```
 
 Unlike icons, the variance of splash file is larger. You likely want to download the following [splash svg template](/examples/safe-splash-template.svg). The source svg should have a background filling the entire area, and icons / text should be kept to the 'safe area' box.
 

--- a/pages/workflow/icon_splash_management.md
+++ b/pages/workflow/icon_splash_management.md
@@ -9,7 +9,13 @@ For both, platform & icon source are configurable as documented [in the cli](/pa
 
 ## Icon Generation
 
-Place an icon.svg file at ember-cordova/icon.svg and run `ember cdv:make-icons`. Icons will be resized injected.
+Place an icon.svg file at ember-cordova/icon.svg and run `ember cdv:make-icons`. By default, icons for all platforms will be resized injected.
+
+To specify a single platform, use the `--platform` option with the desired platform.
+
+```
+ember cdv:make-icons --platform ios
+```
 
 The source svg should be a square of any size.
 


### PR DESCRIPTION
This PR add documentation for the default behaviour of `ember cdv:make-icons` and `ember cdv:make-splashes` and the optional `--platform` argument. 