### PR TITLE
cdv:open handling for android platform

### DIFF
--- a/lib/tasks/open-app.js
+++ b/lib/tasks/open-app.js
@@ -26,9 +26,18 @@ module.exports = Task.extend({
       } else if (this.platform === 'android') {
         var projectFile = path.join(cdvPath, 'platforms/android/.project');
 
-        projectPath = fs.existsSync(projectFile) ?
-          projectFile :
-          path.join(cdvPath, 'platforms/android/');
+        if (fs.existsSync(projectFile)) {
+          projectPath = projectFile;
+        } else {
+          var docLink = 'http://embercordova.com/pages/cli#open';
+
+          logger.warn('Can\'t open IDE without a project being created. See' +
+            docLink +
+            'for more info.'
+          );
+
+          projectPath = path.join(cdvPath, 'platforms/android/');
+        }
 
       } else {
         reject(

--- a/lib/tasks/open-app.js
+++ b/lib/tasks/open-app.js
@@ -4,6 +4,7 @@ var Task               = require('./-task');
 var BashTask           = require('../tasks/bash');
 var Promise            = require('ember-cli/lib/ext/promise');
 var logger             = require('../utils/logger');
+var fs                 = require('fs');
 
 var path               = require('path');
 var getOpenCommand     = require('../utils/open-app-command');
@@ -23,7 +24,11 @@ module.exports = Task.extend({
         projectPath = path.join(cdvPath, 'platforms/ios/*.xcodeproj');
 
       } else if (this.platform === 'android') {
-        projectPath = path.join(cdvPath, 'platforms/android/.project');
+        var projectFile = path.join(cdvPath, 'platforms/android/.project');
+
+        projectPath = fs.existsSync(projectFile) ?
+          projectFile :
+          path.join(cdvPath, 'platforms/android/');
 
       } else {
         reject(

--- a/lib/utils/open-app-command.js
+++ b/lib/utils/open-app-command.js
@@ -10,7 +10,8 @@ module.exports = function(target, appName) {
   switch (process.platform) {
     case 'darwin':
       if (appName) {
-        opener = 'open -a "' + escape(appName) + '"';
+
+        opener = 'open -a "' + appName + '"';
       } else {
         opener = 'open';
       }
@@ -19,14 +20,14 @@ module.exports = function(target, appName) {
       // if the first parameter to start is quoted, it uses that as the title
       // so we pass a blank title so we can quote the file we are opening
       if (appName) {
-        opener = 'start "" "' + escape(appName) + '"';
+        opener = 'start "" "' + appName + '"';
       } else {
         opener = 'start';
       }
       break;
     default:
       if (appName) {
-        opener = escape(appName);
+        opener = appName;
       } else {
         // use Portlands xdg-open everywhere else
         opener = 'xdg-open';

--- a/node-tests/unit/tasks/open-app-test.js
+++ b/node-tests/unit/tasks/open-app-test.js
@@ -39,7 +39,7 @@ describe('Open App Task', function() {
     openApp.platform = 'android';
     openApp.run();
 
-    var expectedPath = cdvPath + '/platforms/android/.project';
+    var expectedPath = cdvPath + '/platforms/android/';
     var expectedCmd  = openCommand(expectedPath);
     td.verify(bashDouble(expectedCmd, isObject));
   }),


### PR DESCRIPTION
I spent time with this issue #171  and found that Cordova builds do create the directory needed to open iOS projects as expected but they do not generate the .project file we are looking for in the same command. Furthermore looking [here](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#debugging) I found we can import the project into the IDE using the `platforms/android` directory.

this change will check for a .project file and if there is none use the `platform/android` in its place.