### PR TITLE
Fix Duplicate config.xml Nodes Being Added By make-icons and make-splashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "portfinder": "^1.0.5",
     "rimraf": "^2.5.4",
     "rsvp": "^3.2.1",
-    "splicon": "0.0.9",
+    "splicon": "0.0.10",
     "svg2png": "^4.1.0",
     "uuid": "^3.0.0",
     "xml2js": "^0.4.17"


### PR DESCRIPTION
Fixes duplicate config.xml nodes being added by `make-icons` and `make-splashes` (https://github.com/isleofcode/ember-cordova/issues/217).