### PR TITLE
Change WebView defaults & flags

### DIFF
--- a/lib/commands/platform.js
+++ b/lib/commands/platform.js
@@ -4,7 +4,6 @@ var Command         = require('./-command');
 var CordovaRawTask  = require('../tasks/cordova-raw');
 var SanitizeArgs    = require('../tasks/validate/sanitize-addon-args');
 var SetupWebView    = require('../tasks/setup-webview');
-var Promise         = require('rsvp').Promise;
 var logger          = require('../utils/logger');
 
 module.exports = Command.extend({
@@ -17,6 +16,8 @@ module.exports = Command.extend({
   availableOptions: [
     { name: 'save',                 type: Boolean,  default: true },
     { name: 'default-webview',      type: Boolean,  default: false },
+    { name: 'crosswalk',            type: Boolean,  default: false },
+    { name: 'uiwebview',            type: Boolean,  default: false },
     { name: 'link',                 type: String,  default: undefined }
   ],
 
@@ -35,6 +36,7 @@ module.exports = Command.extend({
       rawApi: 'platforms'
     });
 
+    //TODO - flatten validator /w SetupWebView
     return cordovaArgValidator.run()
       .then(function(validated) {
         var action = validated.action;
@@ -47,19 +49,17 @@ module.exports = Command.extend({
         return platformTask.run(validated.action, validated.name, opts)
           .then(function() {
             //By default we upgrade the default WebView
-            //See ${DOCLINK} TODO
             var platform = validated.name;
 
-            if (action === 'add' && options.defaultWebview !== true &&
-                (platform === 'ios' || platform === 'android')) {
-
+            if (action === 'add') {
               var setup = new SetupWebView({
                 project: project,
-                platform: platform
+                platform: platform,
+                crosswalk: options.crosswalk,
+                uiwebview: options.uiwebview
               });
+
               return setup.run();
-            } else {
-              return Promise.resolve();
             }
           });
       }).catch(function(err) {

--- a/lib/tasks/setup-webview.js
+++ b/lib/tasks/setup-webview.js
@@ -3,10 +3,20 @@
 var Task            = require('./-task');
 var CordovaRawTask  = require('../tasks/cordova-raw');
 var logger          = require('../utils/logger');
+var Promise         = require('rsvp').Promise;
 
 module.exports = Task.extend({
   project: undefined,
   platform: undefined,
+  uiwebview: false,
+  crosswalk: false,
+
+  warnPlatform: function(platform, view) {
+    logger.warn(
+      'You have specified platform=' + platform + ' and ' + view + '.' +
+      'Crosswalk is only available on android. This will have no effect.'
+    );
+  },
 
   run: function() {
     var viewName, upgradeWebView;
@@ -17,21 +27,32 @@ module.exports = Task.extend({
     });
 
     if (this.platform === 'ios') {
-      viewName = 'cordova-plugin-wkwebview-engine';
+      if (this.crosswalk === true) {
+        this.warnPlatform('ios', 'crosswalk=true');
+      } else if (this.uiwebview === false) {
+        viewName = 'cordova-plugin-wkwebview-engine';
+      }
     } else if (this.platform === 'android') {
-      viewName = 'cordova-plugin-crosswalk-webview';
+      if (this.uiwebview === true) {
+        this.warnPlatform('android', 'uiwebview=true');
+      } else if (this.crosswalk === true) {
+        viewName = 'cordova-plugin-crosswalk-webview';
+      }
     }
 
     logger.warn(
       'ember-cordova initializes with upgraded WebViews. ' +
-      'See http://ember-cordova.com/pages/default_webviews for details. ' +
-      'If you want default cordova views, pass --default-webview=true.'
+      'See http://ember-cordova.com/pages/default_webviews for details and flags'
     );
 
     logger.success(
       'Initializing cordova with upgraded WebView ' + viewName
     );
 
-    return upgradeWebView.run('add', viewName, { save: true });
+    if (viewName !== undefined) {
+      return upgradeWebView.run('add', viewName, { save: true });
+    } else {
+      return Promise.resolve();
+    }
   }
 });

--- a/lib/tasks/setup-webview.js
+++ b/lib/tasks/setup-webview.js
@@ -18,6 +18,13 @@ module.exports = Task.extend({
     );
   },
 
+  warnIosView: function() {
+    logger.warn(
+      'ember-cordova initializes ios with the upgraded WKWebView. ' +
+      'See http://ember-cordova.com/pages/default_webviews for details and flags'
+    );
+  },
+
   run: function() {
     var viewName, upgradeWebView;
 
@@ -30,6 +37,7 @@ module.exports = Task.extend({
       if (this.crosswalk === true) {
         this.warnPlatform('ios', 'crosswalk=true');
       } else if (this.uiwebview === false) {
+        this.warnIosView();
         viewName = 'cordova-plugin-wkwebview-engine';
       }
     } else if (this.platform === 'android') {
@@ -39,11 +47,6 @@ module.exports = Task.extend({
         viewName = 'cordova-plugin-crosswalk-webview';
       }
     }
-
-    logger.warn(
-      'ember-cordova initializes with upgraded WebViews. ' +
-      'See http://ember-cordova.com/pages/default_webviews for details and flags'
-    );
 
     logger.success(
       'Initializing cordova with upgraded WebView ' + viewName

--- a/node-tests/unit/commands/platform-test.js
+++ b/node-tests/unit/commands/platform-test.js
@@ -69,25 +69,11 @@ describe('Platform Command', function() {
       });
     });
 
-    it('attempts to upgrade default webviews', function() {
+    it('calls SetupWebView to handle init', function() {
       var setupViewDouble = td.replace(SetupViewTask.prototype, 'run');
 
       return platform.run({}, ['add', 'ios']).then(function() {
         td.verify(setupViewDouble());
-      });
-    });
-
-    it('uses cordova defaults if --default-webview is true', function() {
-      var called = false;
-      td.replace(SetupViewTask.prototype, 'run', function() {
-        called = true;
-        return Promise.resolve();
-      });
-
-      var opts = { defaultWebview: true };
-
-      return platform.run(opts, ['add', 'ios']).then(function() {
-        expect(called).to.equal(false);
       });
     });
   });

--- a/node-tests/unit/tasks/setup-webview-test.js
+++ b/node-tests/unit/tasks/setup-webview-test.js
@@ -32,13 +32,13 @@ describe('Setup Webview Task', function() {
     td.verify(rawDouble(isAnything, isAnything, isAnything));
   });
 
-  it('warns the user & alerts them of install', function() {
+  it('warns the user of default changes in ios', function() {
     var warnDouble = td.replace(logger, 'warn');
     var successDouble = td.replace(logger, 'success');
 
     setupTask.run();
     td.verify(warnDouble(contains(
-      'ember-cordova initializes with upgraded WebViews.'
+      'ember-cordova initializes ios with the upgraded WKWebView'
     )));
 
     td.verify(successDouble(contains(

--- a/node-tests/unit/tasks/setup-webview-test.js
+++ b/node-tests/unit/tasks/setup-webview-test.js
@@ -77,4 +77,23 @@ describe('Setup Webview Task', function() {
     setupTask.run();
     td.verify(rawDouble('add', 'cordova-plugin-wkwebview-engine', isAnything));
   });
+
+  describe('invalid platform/webview combinations', function() {
+    it('warns ios users if crosswalk=true', function() {
+      setupTask.crosswalk = true;
+      let warnDouble = td.replace(setupTask, 'warnPlatform');
+
+      setupTask.run();
+      td.verify(warnDouble('ios', 'crosswalk=true'));
+    });
+
+    it('warns android users if uiwebview=true', function() {
+      setupTask.platform = 'android';
+      setupTask.uiwebview = true;
+      let warnDouble = td.replace(setupTask, 'warnPlatform');
+
+      setupTask.run();
+      td.verify(warnDouble('android', 'uiwebview=true'));
+    });
+  });
 });

--- a/node-tests/unit/tasks/setup-webview-test.js
+++ b/node-tests/unit/tasks/setup-webview-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var td              = require('testdouble');
+var expect          = require('../../helpers/expect');
 var isAnything      = td.matchers.anything();
 var logger          = require('../../../lib/utils/logger');
 
@@ -45,14 +46,35 @@ describe('Setup Webview Task', function() {
     )));
   });
 
-  it('uses cordova-plugin-wkwebview-engine for ios', function() {
-    setupTask.run();
-    td.verify(rawDouble('add', 'cordova-plugin-wkwebview-engine', isAnything));
+  it('defaults to crosswalk=false', function() {
+    expect(setupTask.crosswalk).to.equal(false);
   });
 
-  it('uses cordova-plugin-crosswalk-webview for android', function() {
+  it('defaults to uiwebview=false', function() {
+    expect(setupTask.uiwebview).to.equal(false);
+  });
+
+  it('when crosswalk=false(default), it uses android default', function() {
     setupTask.platform = 'android';
     setupTask.run();
+    td.verify(rawDouble(), {times: 0, ignoreExtraArgs: true});
+  });
+
+  it('when uiwebview=true, it uses ios default webview', function() {
+    setupTask.uiwebview = true;
+    setupTask.run();
+    td.verify(rawDouble(), {times: 0, ignoreExtraArgs: true});
+  });
+
+  it('when crosswalk=true, it uses crosswalk', function() {
+    setupTask.platform = 'android';
+    setupTask.crosswalk = true;
+    setupTask.run();
     td.verify(rawDouble('add', 'cordova-plugin-crosswalk-webview', isAnything));
+  });
+
+  it('when uiwebview=false(default), it uses wkwebview', function() {
+    setupTask.run();
+    td.verify(rawDouble('add', 'cordova-plugin-wkwebview-engine', isAnything));
   });
 });


### PR DESCRIPTION
- The `--default-webview` flag has been deprecated;
- Due to project deprecation, Crosswalk is no longer the Android default. Android platforms initialize with the stock WebView. Crosswalk can still be installed with `ember cdv:platform add android --crosswalk`;
- For iOS, you can revert to a UIWebView with `ember cdv:platform add ios --uiwebview`;