### PR TITLE
refactor(commands.build): Run 'before-build' hook before validations.

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -130,8 +130,8 @@ module.exports = Command.extend({
 
     logger.info('ember-cordova: Building app');
 
-    return this.startValidators(project, options)
-      .then(hook.prepare('beforeBuild', options))
+    return hook.run('beforeBuild', options)
+      .then(this.startValidators.bind(this, project, options))
       .then(function() {
         if (options.skipEmberBuild !== true) {
           return emberBuild.run();

--- a/node-tests/unit/commands/build-test.js
+++ b/node-tests/unit/commands/build-test.js
@@ -108,10 +108,10 @@ describe('Build Command', function() {
         .then(function() {
           //h-t ember-electron for the pattern
           expect(tasks).to.deep.equal([
+            'hook beforeBuild',
             'validate-root-url',
             'validate-allow-navigation',
             'validate-platform',
-            'hook beforeBuild',
             'ember-build',
             'cordova-build',
             'hook afterBuild',
@@ -127,10 +127,10 @@ describe('Build Command', function() {
         .then(function() {
           //h-t ember-electron for the pattern
           expect(tasks).to.deep.equal([
+            'hook beforeBuild',
             'validate-root-url',
             'validate-allow-navigation',
             'validate-platform',
-            'hook beforeBuild',
             'cordova-build',
             'hook afterBuild',
             'lint-index'
@@ -145,9 +145,9 @@ describe('Build Command', function() {
         .then(function() {
           //h-t ember-electron for the pattern
           expect(tasks).to.deep.equal([
+            'hook beforeBuild',
             'validate-root-url',
             'validate-allow-navigation',
-            'hook beforeBuild',
             'ember-build',
             'hook afterBuild',
             'lint-index'


### PR DESCRIPTION
Currently we can't use the `before-build` hook to make arrangements into `config/environment.js` because the validations run before this hook.

Runnig the hook before validations gives us the opportunity to tune the configuration file up properly to make the app work in a Cordova context.
