### PR TITLE
[FEATURE] Support for new android assets path

### DIFF
--- a/lib/utils/cordova-assets.js
+++ b/lib/utils/cordova-assets.js
@@ -10,7 +10,7 @@ module.exports = {
     if (platform === 'ios') {
       assetsPath = path.join(platformsPath, 'ios', 'www');
     } else if (platform === 'android') {
-      assetsPath = path.join(platformsPath, 'android', 'assets', 'www');
+      assetsPath = path.join(platformsPath, 'android', 'app', 'src', 'main', 'assets', 'www');
     } else if (platform === 'browser') {
       assetsPath = path.join(platformsPath, 'browser', 'www');
     }

--- a/node-tests/unit/utils/cordova-assets-test.js
+++ b/node-tests/unit/utils/cordova-assets-test.js
@@ -17,7 +17,7 @@ describe('Get Platform Assets Util', function() {
 
     it('is valid for android', function() {
       var assets = cordovaAssets.getPaths('android', 'fakeProjectPath');
-      var expectedPath = 'platforms/android/assets/www';
+      var expectedPath = 'platforms/android/app/src/main/assets/www';
       expect(assets.assetsPath).to.equal(expectedPath);
     });
 


### PR DESCRIPTION
Since cordova-android 7.0 the assets path is now different. Doing a `ember cdv:serve --platform=android` was not working for Android.